### PR TITLE
Bugfix Python 3: defining `__eq__` disables `__hash__` inheritance

### DIFF
--- a/src/rfc3986/uri.py
+++ b/src/rfc3986/uri.py
@@ -98,7 +98,7 @@ class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS)):
         return ref
 
     __hash__ = tuple.__hash__
-    
+
     def __eq__(self, other):
         """Compare this reference to another."""
         other_ref = other

--- a/src/rfc3986/uri.py
+++ b/src/rfc3986/uri.py
@@ -97,6 +97,8 @@ class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS)):
         ref.encoding = encoding
         return ref
 
+    __hash__ = tuple.__hash__
+    
     def __eq__(self, other):
         """Compare this reference to another."""
         other_ref = other


### PR DESCRIPTION
Fix for Python3 `__eq__` disables inheritance of `__hash__`