### PR TITLE
Stop validating Zone IDs before normalization

### DIFF
--- a/src/rfc3986/misc.py
+++ b/src/rfc3986/misc.py
@@ -58,6 +58,7 @@ SUBAUTHORITY_MATCHER = re.compile((
              abnf_regexp.PORT_RE))
 
 
+HOST_MATCHER = re.compile('^' + abnf_regexp.HOST_RE + '$')
 IPv4_MATCHER = re.compile('^' + abnf_regexp.IPv4_RE + '$')
 IPv6_MATCHER = re.compile(r'^\[' + abnf_regexp.IPv6_ADDRZ_RFC4007_RE + r'\]$')
 

--- a/src/rfc3986/uri.py
+++ b/src/rfc3986/uri.py
@@ -171,12 +171,6 @@ class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS)):
             # valid bytes, it is an InvalidAuthority.
             raise exc.InvalidAuthority(self.authority.encode(self.encoding))
 
-        if (host and misc.IPv6_MATCHER.match(host) and not
-                misc.IPv6_NO_RFC4007_MATCHER.match(host)):
-            # If it's an IPv6 address that has RFC 4007 IPv6
-            # Zone IDs then it's invalid.
-            raise exc.InvalidAuthority(self.authority.encode(self.encoding))
-
         return matches
 
     @property

--- a/src/rfc3986/validators.py
+++ b/src/rfc3986/validators.py
@@ -304,6 +304,24 @@ def authority_is_valid(authority, host=None, require=False):
         bool
     """
     validated = is_valid(authority, misc.SUBAUTHORITY_MATCHER, require)
+    if validated and host is not None:
+        return host_is_valid(host, require)
+    return validated
+
+
+def host_is_valid(host, require=False):
+    """Determine if the host string is valid.
+
+    :param str host:
+        The host to validate.
+    :param bool require:
+        (optional) Specify if host must not be None.
+    :returns:
+        ``True`` if valid, ``False`` otherwise
+    :rtype:
+        bool
+    """
+    validated = is_valid(host, misc.HOST_MATCHER, require)
     if validated and host is not None and misc.IPv4_MATCHER.match(host):
         return valid_ipv4_host_address(host)
     elif validated and host is not None and misc.IPv6_MATCHER.match(host):
@@ -397,7 +415,9 @@ def subauthority_component_is_valid(uri, component):
 
     # If we can parse the authority into sub-components and we're not
     # validating the port, we can assume it's valid.
-    if component != 'port':
+    if component == 'host':
+        return host_is_valid(subauthority_dict['host'], require=True)
+    elif component != 'port':
         return True
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,7 @@ invalid_hosts = [
     '[FF02::3::5]',  # IPv6 can only have one ::
     '[FADF:01]',  # Not properly compacted (missing a :)
     '[FADF:01%en0]',  # Not properly compacted (missing a :), Invalid ZoneID
-    '[FADF::01%en0]',  # ZoneID is per RFC 4007
-    '[FADF::01%]',  # Invalid ZoneID separator and no ZoneID
-    '[FADF::01%25]',  # Missing ZoneID in RFC 6974, is 25 in RFC 4007
+    '[FADF::01%]',  # Empty Zone ID
     'localhost:80:80:80',  # Too many ports
     '256.256.256.256',  # Invalid IPv4 Address
     SNOWMAN.decode('utf-8')

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -79,6 +79,19 @@ def test_add_host(hostname):
     assert uribuilder.host == 'google.com'
 
 
+@pytest.mark.parametrize('host', [
+    '[::ff%etH0]',
+    '[::ff%25etH0]',
+    '[::FF%etH0]',
+])
+def test_add_host_ipv6_zone_ids(host):
+    """Verify we normalize IPv6 Zone IDs in add_host."""
+    uri = builder.URIBuilder().add_scheme('https').add_host(host).finalize(
+    ).unsplit()
+    expected = 'https://[::ff%25etH0]'
+    assert expected == uri
+
+
 @pytest.mark.parametrize('port', [
     -100,
     '-100',

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -73,6 +73,12 @@ def test_authority_normalization():
     assert uri.authority == 'user%2AName@example.com'
 
 
+def test_ipv6_zone_id_normalization():
+    uri = URIReference(
+        None, '[::1%eth0]', None, None, None, None).normalize()
+    assert uri.authority == '[::1%25eth0]'
+
+
 def test_fragment_normalization():
     uri = URIReference(
         None, 'example.com', None, None, 'fiz%DF').normalize()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -235,3 +235,12 @@ def test_invalid_uri_with_invalid_path(invalid_uri):
         validators.Validator().check_validity_of(
             'host', 'path',
         ).validate(uri)
+
+
+def test_rfc_4007_ipv6_zone_ids_invalid_host():
+    """Verify that RFC 4007 IPv6 Zone IDs are invalid host/authority"""
+    uri = rfc3986.uri_reference("http://[::1%eth0]")
+    with pytest.raises(exceptions.InvalidComponentsError):
+        validators.Validator().check_validity_of(
+            'host'
+        ).validate(uri)


### PR DESCRIPTION
Closes #44 for a second time. This allows normalization to occur on `URIReference`s with an RFC 4007 Zone ID.