### PR TITLE
Don't require host to be valid

### DIFF
--- a/src/rfc3986/validators.py
+++ b/src/rfc3986/validators.py
@@ -416,7 +416,7 @@ def subauthority_component_is_valid(uri, component):
     # If we can parse the authority into sub-components and we're not
     # validating the port, we can assume it's valid.
     if component == 'host':
-        return host_is_valid(subauthority_dict['host'], require=True)
+        return host_is_valid(subauthority_dict['host'])
     elif component != 'port':
         return True
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -105,6 +105,8 @@ def test_passwordless_uris_pass_validation(uri):
 ])
 def test_missing_host_component(uri):
     """Verify that missing host components cause errors."""
+    validators.Validator().validate(uri)
+
     validator = validators.Validator().require_presence_of('host')
     with pytest.raises(exceptions.MissingComponentError):
         validator.validate(uri)


### PR DESCRIPTION
Little oversight by me, components don't need to be non-None to be valid.