### PR TITLE
Don't unconditionally lowercase host parts

### DIFF
--- a/src/rfc3986/iri.py
+++ b/src/rfc3986/iri.py
@@ -118,10 +118,12 @@ class IRIReference(namedtuple('IRIReference', misc.URI_COMPONENTS),
                     )
                 else:
                     def idna_encoder(x):
-                        try:
-                            return idna.encode(x.lower(), strict=True, std3_rules=True)
-                        except idna.IDNAError:
-                            raise exceptions.InvalidAuthority(self.authority)
+                        if any(ord(c) > 128 for c in x):
+                            try:
+                                return idna.encode(x.lower(), strict=True, std3_rules=True)
+                            except idna.IDNAError:
+                                raise exceptions.InvalidAuthority(self.authority)
+                        return x
 
             authority = ""
             if self.host:

--- a/src/rfc3986/iri.py
+++ b/src/rfc3986/iri.py
@@ -119,13 +119,13 @@ class IRIReference(namedtuple('IRIReference', misc.URI_COMPONENTS),
                 else:
                     def idna_encoder(x):
                         try:
-                            return idna.encode(x, strict=True, std3_rules=True)
+                            return idna.encode(x.lower(), strict=True, std3_rules=True)
                         except idna.IDNAError:
                             raise exceptions.InvalidAuthority(self.authority)
 
             authority = ""
             if self.host:
-                authority = ".".join([compat.to_str(idna_encoder(part.lower()))
+                authority = ".".join([compat.to_str(idna_encoder(part))
                                       for part in self.host.split(".")])
 
             if self.userinfo is not None:

--- a/src/rfc3986/iri.py
+++ b/src/rfc3986/iri.py
@@ -94,7 +94,7 @@ class IRIReference(namedtuple('IRIReference', misc.URI_COMPONENTS),
             encoding,
         )
 
-    def encode(self, idna_encoder=None):
+    def encode(self, idna_encoder=None):  # noqa: C901
         """Encode an IRIReference into a URIReference instance.
 
         If the ``idna`` module is installed or the ``rfc3986[idna]``
@@ -116,14 +116,16 @@ class IRIReference(namedtuple('IRIReference', misc.URI_COMPONENTS),
                         "Could not import the 'idna' module "
                         "and the IRI hostname requires encoding"
                     )
-                else:
-                    def idna_encoder(x):
-                        if any(ord(c) > 128 for c in x):
-                            try:
-                                return idna.encode(x.lower(), strict=True, std3_rules=True)
-                            except idna.IDNAError:
-                                raise exceptions.InvalidAuthority(self.authority)
-                        return x
+
+                def idna_encoder(name):
+                    if any(ord(c) > 128 for c in name):
+                        try:
+                            return idna.encode(name.lower(),
+                                               strict=True,
+                                               std3_rules=True)
+                        except idna.IDNAError:
+                            raise exceptions.InvalidAuthority(self.authority)
+                    return name
 
             authority = ""
             if self.host:

--- a/tests/test_iri.py
+++ b/tests/test_iri.py
@@ -19,10 +19,11 @@ iri_to_uri = pytest.mark.parametrize(
         (u'http://βόλος.com/β/ό?λ#ος', u'http://xn--nxasmm1c.com/%CE%B2/%CF%8C?%CE%BB#%CE%BF%CF%82'),
         (u'http://ශ්\u200dරී.com', u'http://xn--10cl1a0b660p.com'),
         (u'http://نامه\u200cای.com', u'http://xn--mgba3gch31f060k.com'),
-        (u'http://Bü:ẞ@gOoGle.com', u'http://B%C3%BC:%E1%BA%9E@google.com'),
+        (u'http://Bü:ẞ@gOoGle.com', u'http://B%C3%BC:%E1%BA%9E@gOoGle.com'),
         (u'http://ẞ.com:443', u'http://xn--zca.com:443'),
         (u'http://ẞ.foo.com', u'http://xn--zca.foo.com'),
-        (u'http+unix://%2Ftmp%2FTEST.sock/get', 'http+unix"//%2Ftmp%2FTEST.sock/get'),
+        (u'http://Bẞ.com', u'http://xn--b-qfa.com'),
+        (u'http+unix://%2Ftmp%2FTEST.sock/get', 'http+unix://%2Ftmp%2FTEST.sock/get'),
     ]
 )
 
@@ -50,8 +51,7 @@ def test_iri_equality_special_cases():
 @pytest.mark.parametrize("iri", [
     u'http://♥.net',
     u'http://\u0378.net',
-    u'http://㛼.com',
-    u'http://abc..def'
+    u'http://㛼.com'
 ])
 def test_encode_invalid_iri(iri):
     iri_ref = rfc3986.iri_reference(iri)

--- a/tests/test_iri.py
+++ b/tests/test_iri.py
@@ -21,7 +21,8 @@ iri_to_uri = pytest.mark.parametrize(
         (u'http://نامه\u200cای.com', u'http://xn--mgba3gch31f060k.com'),
         (u'http://Bü:ẞ@gOoGle.com', u'http://B%C3%BC:%E1%BA%9E@google.com'),
         (u'http://ẞ.com:443', u'http://xn--zca.com:443'),
-        (u'http://ẞ.foo.com', u'http://xn--zca.foo.com')
+        (u'http://ẞ.foo.com', u'http://xn--zca.foo.com'),
+        (u'http+unix://%2Ftmp%2FTEST.sock/get', 'http+unix"//%2Ftmp%2FTEST.sock/get'),
     ]
 )
 


### PR DESCRIPTION
Found issues when dealing with URIs that use `http+unix` and some inconsistencies between what is a valid authority for URIs versus IRIs (ie empty labels).

Things I changed:
- Don't universally lowercase, only before sending into `idna.encode()` otherwise it'll error out.
- Don't consider an empty label an `InvalidAuthority`. Maybe this is something to add in the future to URI and IRI?
- Only run `idna.encode()` if the unicode character is non-ASCII.