### PR TITLE
fixed userinfo regex for @ character in userinfo

### DIFF
--- a/src/rfc3986/abnf_regexp.py
+++ b/src/rfc3986/abnf_regexp.py
@@ -134,8 +134,8 @@ HOST_RE = HOST_PATTERN = '({0}|{1}|{2})'.format(
     IPv4_RE,
     IP_LITERAL_RE,
 )
-USERINFO_RE = '^([' + UNRESERVED_RE + SUB_DELIMITERS_RE + ':]|%s)+' % (
-    PCT_ENCODED
+USERINFO_RE = '^([%s%s:]|%s)+.*(?=@)' % (
+    UNRESERVED_RE, SUB_DELIMITERS_RE, PCT_ENCODED
 )
 PORT_RE = '[0-9]{1,5}'
 
@@ -241,8 +241,8 @@ IHOST_RE = IHOST_PATTERN = u'({0}|{1}|{2})'.format(
     IP_LITERAL_RE,
 )
 
-IUSERINFO_RE = u'^(?:[' + IUNRESERVED_RE + SUB_DELIMITERS_RE + u':]|%s)+' % (
-    PCT_ENCODED
+IUSERINFO_RE = u'^(?:[%s%s:]|%s)+.*(?=@)' % (
+    IUNRESERVED_RE, SUB_DELIMITERS_RE, PCT_ENCODED
 )
 
 IFRAGMENT_RE = (u'^(?:[/?:@' + IUNRESERVED_RE + SUB_DELIMITERS_RE

--- a/tests/base.py
+++ b/tests/base.py
@@ -58,6 +58,21 @@ class BaseTestParsesURIs:
         assert uri.fragment is None
         assert uri.userinfo == 'user:pass'
 
+    def test_handles_uri_with_email_userinfo(
+            self, uri_with_email_userinfo):
+        """
+        Test that self.test_class can handle a URI with a port and userinfo.
+        """
+        uri = self.test_class.from_string(uri_with_email_userinfo)
+        assert uri.scheme == 'ssh'
+        # 6 == len('ftp://')
+        assert uri.authority == uri_with_email_userinfo[6:]
+        assert uri.host != uri.authority
+        assert uri.path is None
+        assert uri.query is None
+        assert uri.fragment is None
+        assert uri.userinfo == 'user@email.com:pass'
+
     def test_handles_tricky_userinfo(
             self, uri_with_port_and_tricky_userinfo):
         """
@@ -149,6 +164,11 @@ class BaseTestUnsplits:
                                                  uri_with_port_and_userinfo):
         uri = self.test_class.from_string(uri_with_port_and_userinfo)
         assert uri.unsplit() == uri_with_port_and_userinfo
+
+    def test_uri_with_email_userinfo_unsplits(self,
+                                                 uri_with_email_userinfo):
+        uri = self.test_class.from_string(uri_with_email_userinfo)
+        assert uri.unsplit() == uri_with_email_userinfo
 
     def test_basic_uri_with_path_unsplits(self, basic_uri_with_path):
         uri = self.test_class.from_string(basic_uri_with_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,10 @@ def basic_uri_with_port(request):
 def uri_with_port_and_userinfo(request):
     return 'ssh://user:pass@%s:22' % request.param
 
+@pytest.fixture(params=valid_hosts)
+def uri_with_email_userinfo(request):
+    return 'ssh://user@email.com:pass@%s' % request.param
+
 
 @pytest.fixture(params=valid_hosts)
 def uri_with_port_and_tricky_userinfo(request):

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -99,6 +99,11 @@ class TestURIValidation:
         uri = URIReference.from_string(uri_with_port_and_userinfo)
         assert uri.is_valid() is True
 
+    def test_uri_with_email_userinfo_is_valid(self,
+                                                 uri_with_email_userinfo):
+        uri = URIReference.from_string(uri_with_email_userinfo)
+        assert uri.is_valid() is True
+
     def test_basic_uri_with_path_is_valid(self, basic_uri_with_path):
         uri = URIReference.from_string(basic_uri_with_path)
         assert uri.is_valid() is True
@@ -166,6 +171,10 @@ class TestURIReferenceComparesToStrings:
         uri = URIReference.from_string(uri_with_port_and_userinfo)
         assert uri == uri_with_port_and_userinfo
 
+    def test_uri_with_email_userinfo(self, uri_with_email_userinfo):
+        uri = URIReference.from_string(uri_with_email_userinfo)
+        assert uri == uri_with_email_userinfo
+
     def test_basic_uri_with_path(self, basic_uri_with_path):
         uri = URIReference.from_string(basic_uri_with_path)
         assert uri == basic_uri_with_path
@@ -206,6 +215,10 @@ class TestURIReferenceComparesToTuples:
     def test_uri_with_port_and_userinfo(self, uri_with_port_and_userinfo):
         uri = URIReference.from_string(uri_with_port_and_userinfo)
         assert uri == self.to_tuple(uri_with_port_and_userinfo)
+
+    def test_uri_with_email_userinfo(self, uri_with_email_userinfo):
+        uri = URIReference.from_string(uri_with_email_userinfo)
+        assert uri == self.to_tuple(uri_with_email_userinfo)
 
     def test_basic_uri_with_path(self, basic_uri_with_path):
         uri = URIReference.from_string(basic_uri_with_path)


### PR DESCRIPTION
`USERINFO_RE` regex pattern separates URL by first @ character. I changed this pattern to evaluate the last @ character so that can use an email address for userinfo.username (e.g. "https://user@gmail.com:password@example.com")