### PR TITLE
Handle `@` characters in the userinfo section.

### DIFF
--- a/src/rfc3986/_mixin.py
+++ b/src/rfc3986/_mixin.py
@@ -51,7 +51,7 @@ class URIMixin(object):
         return matches
 
     def _match_subauthority(self):
-        # Follow the whatwg spec by urlencoding any '@' in the userinfo section.
+        # Follow the whatwg spec by urlencoding any '@' in the URL userinfo.
         # This is classed as a non-parser terminating validation error.
         ampersand_count = self.authority.count("@")
         authority = self.authority.replace("@", "%40", ampersand_count - 1)

--- a/src/rfc3986/_mixin.py
+++ b/src/rfc3986/_mixin.py
@@ -51,7 +51,12 @@ class URIMixin(object):
         return matches
 
     def _match_subauthority(self):
-        return misc.SUBAUTHORITY_MATCHER.match(self.authority)
+        # Follow the whatwg spec by urlencoding any '@' in the userinfo section.
+        # This is classed as a non-parser terminating validation error.
+        ampersand_count = self.authority.count("@")
+        authority = self.authority.replace("@", "%40", ampersand_count - 1)
+
+        return misc.SUBAUTHORITY_MATCHER.match(authority)
 
     @property
     def host(self):

--- a/tests/test_unicode_support.py
+++ b/tests/test_unicode_support.py
@@ -50,10 +50,10 @@ def test_urlparse_a_unicode_hostname_with_auth():
 
 
 def test_urlparse_an_invalid_authority_parses_port():
-    url = 'http://foo:b@r@[::1]:80/get'
+    url = 'http://foo:b r@[::1]:80/get'
     parsed = urlparse(url)
     assert parsed.port == 80
-    assert parsed.userinfo == 'foo:b%40r'
+    assert parsed.userinfo == 'foo:b r'
     assert parsed.hostname == '[::1]'
 
 

--- a/tests/test_unicode_support.py
+++ b/tests/test_unicode_support.py
@@ -53,7 +53,7 @@ def test_urlparse_an_invalid_authority_parses_port():
     url = 'http://foo:b@r@[::1]:80/get'
     parsed = urlparse(url)
     assert parsed.port == 80
-    assert parsed.userinfo == 'foo:b@r'
+    assert parsed.userinfo == 'foo:b%40r'
     assert parsed.hostname == '[::1]'
 
 

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -351,3 +351,11 @@ def test_empty_querystrings_persist():
     ref = URIReference.from_string(url)
     assert ref.query == ''
     assert ref.unsplit() == url
+
+
+def test_urlencoded_ampersand_in_userinfo():
+    url = 'https://user@gmail.com:password@example.com'
+    ref = URIReference.from_string(url)
+    assert ref.authority == 'user@gmail.com:password@example.com'
+    assert ref.userinfo == 'user%40gmail.com:password'
+    assert ref.host == 'example.com'

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -353,7 +353,7 @@ def test_empty_querystrings_persist():
     assert ref.unsplit() == url
 
 
-def test_urlencoded_ampersand_in_userinfo():
+def test_urlencoded_at_sign_in_userinfo():
     url = 'https://user@gmail.com:password@example.com'
     ref = URIReference.from_string(url)
     assert ref.authority == 'user@gmail.com:password@example.com'


### PR DESCRIPTION
This PR allows handling URLs in the form `https://user@gmail.com:password@google.com`

Currently the `rfc3986` package raises an `InvalidAuthority` exception when calling `authority_info()` on a URL formatted in this way. Or returns `None` when eg. `.host`/`.userinfo` are accessed.

Before this change...
 
```python
>>> u = rfc3986.api.uri_reference("https://user@gmail.com:password@google.com")
>>> u.authority
'user@gmail.com:password@google.com'
>>> u.userinfo  # None
>>> u.host  # None
```

The WHATWG URL spec treats `@` in the userinfo section as a non-parser terminating validation error, and URL encodes the character.  https://url.spec.whatwg.org/#authority-state

After this change, we follow the WHATWG behavior, URL encoding the character if it incorrectly occurs in the userinfo...

```python
>>> u = rfc3986.api.uri_reference("https://user@gmail.com:password@google.com")
>>> u.authority
'user@gmail.com:password@google.com'
>>> u.userinfo
'user%40gmail.com:password'
>>> u.host
'google.com'
```

Raised via https://github.com/encode/httpx/issues/328