### PR TITLE
Fix ParseResultBytes when we have a valid IRI

### DIFF
--- a/docs/source/release-notes/index.rst
+++ b/docs/source/release-notes/index.rst
@@ -10,6 +10,7 @@ here with the newest releases first.
 
 .. toctree::
 
+    unreleased
     1.4.0
     1.3.2
     1.3.1

--- a/docs/source/release-notes/unreleased.rst
+++ b/docs/source/release-notes/unreleased.rst
@@ -1,0 +1,13 @@
+1.x.y - 202z-aa-bb
+------------------
+
+- Fix bug where a valid IRI is mishandled by ``urlparse`` and
+  ``ParseResultBytes``.
+
+  See also `GitHub #57`_
+
+
+.. links
+
+.. _GitHub #57:
+    https://github.com/python-hyper/rfc3986/issues/57

--- a/src/rfc3986/parseresult.py
+++ b/src/rfc3986/parseresult.py
@@ -43,6 +43,8 @@ class ParseResultMixin(object):
                  compat.to_str(host, self.encoding),
                  port)
             )
+        if isinstance(self.authority, bytes):
+            return self.authority.decode('utf-8')
         return self.authority
 
     def geturl(self):

--- a/tests/test_unicode_support.py
+++ b/tests/test_unicode_support.py
@@ -49,6 +49,14 @@ def test_urlparse_a_unicode_hostname_with_auth():
     assert parsed.userinfo == 'userinfo'
 
 
+def test_urlparse_idna_encoding_with_geturl():
+    """https://github.com/python-hyper/rfc3986/issues/57"""
+    parsed = urlparse("https://i❤.ws")
+    encoded = parsed.encode('idna')
+    assert encoded.encoding == 'idna'
+    assert encoded.geturl() == b'https://xn--i-7iq.ws'
+
+
 def test_urlparse_an_invalid_authority_parses_port():
     url = 'http://foo:b@r@[::1]:80/get'
     parsed = urlparse(url)


### PR DESCRIPTION
Closes #57