### PR TITLE
Remove warning message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     package_data={'': ['LICENSE']},
     include_package_data=True,
     license='Apache 2.0',
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -41,7 +41,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ),
+    ],
     extras_require={
         'idna2008':  ['idna']
     }


### PR DESCRIPTION
The warning is as follows:
Warning: 'classifiers' should be a list, got type 'tuple'

Reference:	https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification