### PR TITLE
Fix CI status.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov>=2.0
+attrs==20.1.0

--- a/src/rfc3986/_mixin.py
+++ b/src/rfc3986/_mixin.py
@@ -152,7 +152,9 @@ class URIMixin(object):
             return False
 
         return validators.authority_is_valid(
-            self.authority, host=self.host, require=require,
+            self.authority,
+            host=self.host,
+            require=require,
         )
 
     def scheme_is_valid(self, require=False):

--- a/src/rfc3986/abnf_regexp.py
+++ b/src/rfc3986/abnf_regexp.py
@@ -27,7 +27,7 @@ RESERVED_CHARS_SET = GENERIC_DELIMITERS_SET.union(SUB_DELIMITERS_SET)
 ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 DIGIT = "0123456789"
 # https://tools.ietf.org/html/rfc3986#section-2.3
-UNRESERVED = UNRESERVED_CHARS = ALPHA + DIGIT + r'._!-~'
+UNRESERVED = UNRESERVED_CHARS = ALPHA + DIGIT + r"._!-~"
 UNRESERVED_CHARS_SET = set(UNRESERVED_CHARS)
 NON_PCT_ENCODED_SET = RESERVED_CHARS_SET.union(UNRESERVED_CHARS_SET)
 # We need to escape the '-' in this case:
@@ -123,11 +123,16 @@ ZONE_ID = "(?:[" + UNRESERVED_RE + "]|" + PCT_ENCODED + ")+"
 IPv6_ADDRZ_RFC4007_RE = IPv6_RE + "(?:(?:%25|%)" + ZONE_ID + ")?"
 IPv6_ADDRZ_RE = IPv6_RE + "(?:%25" + ZONE_ID + ")?"
 
-IP_LITERAL_RE = r"\[({0}|{1})\]".format(IPv6_ADDRZ_RFC4007_RE, IPv_FUTURE_RE,)
+IP_LITERAL_RE = r"\[({0}|{1})\]".format(
+    IPv6_ADDRZ_RFC4007_RE,
+    IPv_FUTURE_RE,
+)
 
 # Pattern for matching the host piece of the authority
 HOST_RE = HOST_PATTERN = "({0}|{1}|{2})".format(
-    REG_NAME, IPv4_RE, IP_LITERAL_RE,
+    REG_NAME,
+    IPv4_RE,
+    IP_LITERAL_RE,
 )
 USERINFO_RE = (
     "^([" + UNRESERVED_RE + SUB_DELIMITERS_RE + ":]|%s)+" % (PCT_ENCODED)
@@ -237,7 +242,9 @@ IREGULAR_NAME_RE = IREG_NAME = u"(?:{0}|[{1}])*".format(
 )
 
 IHOST_RE = IHOST_PATTERN = u"({0}|{1}|{2})".format(
-    IREG_NAME, IPv4_RE, IP_LITERAL_RE,
+    IREG_NAME,
+    IPv4_RE,
+    IP_LITERAL_RE,
 )
 
 IUSERINFO_RE = (

--- a/src/rfc3986/builder.py
+++ b/src/rfc3986/builder.py
@@ -137,7 +137,8 @@ class URIBuilder(object):
 
         if password is not None:
             userinfo = "{}:{}".format(
-                userinfo, normalizers.normalize_password(password),
+                userinfo,
+                normalizers.normalize_password(password),
             )
 
         return URIBuilder(
@@ -194,7 +195,9 @@ class URIBuilder(object):
         if port_int > 65535:
             raise ValueError(
                 "ports are not allowed to be larger than 65535. "
-                "You provided {}".format(port_int,)
+                "You provided {}".format(
+                    port_int,
+                )
             )
 
         return URIBuilder(

--- a/src/rfc3986/exceptions.py
+++ b/src/rfc3986/exceptions.py
@@ -74,7 +74,9 @@ class UnpermittedComponentError(ValidationError):
         """Initialize the error with the unpermitted component."""
         super(UnpermittedComponentError, self).__init__(
             "{} was required to be one of {!r} but was {!r}".format(
-                component_name, list(sorted(allowed_values)), component_value,
+                component_name,
+                list(sorted(allowed_values)),
+                component_value,
             ),
             component_name,
             component_value,

--- a/src/rfc3986/validators.py
+++ b/src/rfc3986/validators.py
@@ -250,7 +250,9 @@ def ensure_one_of(allowed_values, uri, attribute):
     value = getattr(uri, attribute)
     if value is not None and allowed_values and value not in allowed_values:
         raise exceptions.UnpermittedComponentError(
-            attribute, value, allowed_values,
+            attribute,
+            value,
+            allowed_values,
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,10 @@ equivalent_schemes = [
     "HtTpS",
 ]
 equivalent_schemes_and_hostnames = list(
-    itertools.product(equivalent_schemes, equivalent_hostnames,)
+    itertools.product(
+        equivalent_schemes,
+        equivalent_hostnames,
+    )
 )
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -65,7 +65,14 @@ def test_repr():
 
 
 @pytest.mark.parametrize(
-    "scheme", ["https", "hTTps", "Https", "HtTpS", "HTTPS",]
+    "scheme",
+    [
+        "https",
+        "hTTps",
+        "Https",
+        "HtTpS",
+        "HTTPS",
+    ],
 )
 def test_add_scheme(scheme):
     """Verify schemes are normalized when added."""
@@ -158,7 +165,11 @@ def test_add_port(port, expected):
 
 
 @pytest.mark.parametrize(
-    "path", ["sigmavirus24/rfc3986", "/sigmavirus24/rfc3986",]
+    "path",
+    [
+        "sigmavirus24/rfc3986",
+        "/sigmavirus24/rfc3986",
+    ],
 )
 def test_add_path(path):
     """Verify we normalize our path value."""

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -31,7 +31,8 @@ def test_allowing_schemes():
 def test_allowing_hosts():
     """Verify the ability to select hosts to be allowed."""
     validator = validators.Validator().allow_hosts(
-        "pypi.python.org", "pypi.org",
+        "pypi.python.org",
+        "pypi.org",
     )
 
     assert "pypi.python.org" in validator.allowed_hosts
@@ -161,7 +162,10 @@ def test_multiple_missing_components(uri):
 
 @pytest.mark.parametrize(
     "uri",
-    [rfc3986.uri_reference("smtp://"), rfc3986.uri_reference("telnet://"),],
+    [
+        rfc3986.uri_reference("smtp://"),
+        rfc3986.uri_reference("telnet://"),
+    ],
 )
 def test_ensure_uri_has_a_scheme(uri):
     """Verify validation with allowed schemes."""
@@ -183,8 +187,14 @@ def test_allowed_hosts_and_schemes(uri, failed_component):
     """Verify each of these fails."""
     validator = (
         validators.Validator()
-        .allow_schemes("https", "ssh",)
-        .allow_hosts("github.com", "git.openstack.org",)
+        .allow_schemes(
+            "https",
+            "ssh",
+        )
+        .allow_hosts(
+            "github.com",
+            "git.openstack.org",
+        )
     )
     with pytest.raises(exceptions.UnpermittedComponentError) as caught_exc:
         validator.validate(uri)
@@ -237,11 +247,22 @@ def test_allowed_hosts_and_schemes(uri, failed_component):
 def test_successful_complex_validation(uri):
     """Verify we do not raise ValidationErrors for good URIs."""
     validators.Validator().allow_schemes("https", "ssh",).allow_hosts(
-        "github.com", "bitbucket.org", "gitlab.com", "git.openstack.org",
+        "github.com",
+        "bitbucket.org",
+        "gitlab.com",
+        "git.openstack.org",
     ).allow_ports("22", "443",).require_presence_of(
-        "scheme", "host", "path",
+        "scheme",
+        "host",
+        "path",
     ).check_validity_of(
-        "scheme", "userinfo", "host", "port", "path", "query", "fragment",
+        "scheme",
+        "userinfo",
+        "host",
+        "port",
+        "path",
+        "query",
+        "fragment",
     ).validate(
         uri
     )
@@ -259,9 +280,10 @@ def test_invalid_uri_with_invalid_path(invalid_uri):
     uri = rfc3986.uri_reference(invalid_uri)
     uri = uri.copy_with(path="#foobar")
     with pytest.raises(exceptions.InvalidComponentsError):
-        validators.Validator().check_validity_of("host", "path",).validate(
-            uri
-        )
+        validators.Validator().check_validity_of(
+            "host",
+            "path",
+        ).validate(uri)
 
 
 def test_validating_rfc_4007_ipv6_zone_ids():


### PR DESCRIPTION
Prompted by the latest test run for this repo having failed, due to black linting... https://travis-ci.org/github/python-hyper/rfc3986/builds/746799781

Also pins `attrs` to 20.1.0 in the `dev-requirements.txt`, since that's the last version to offer Python 3.4 support.

