### PR TITLE
Reject port numbers that aren't composed only of ASCII digits.

### DIFF
--- a/src/rfc3986/parseresult.py
+++ b/src/rfc3986/parseresult.py
@@ -467,7 +467,7 @@ def authority_from(reference, strict):
         )
 
     if port:
-        if port.isascii() and port.isdigit()
+        if port.isascii() and port.isdigit():
             port = int(port)
         else:
             raise exceptions.InvalidPort(port)

--- a/src/rfc3986/parseresult.py
+++ b/src/rfc3986/parseresult.py
@@ -467,8 +467,8 @@ def authority_from(reference, strict):
         )
 
     if port:
-        try:
+        if port.isascii() and port.isdigit()
             port = int(port)
-        except ValueError:
+        else:
             raise exceptions.InvalidPort(port)
     return userinfo, host, port

--- a/tests/test_parseresult.py
+++ b/tests/test_parseresult.py
@@ -18,7 +18,7 @@ from . import base
 from rfc3986 import exceptions
 from rfc3986 import parseresult as pr
 
-INVALID_PORTS = ["443:80", "443:80:443", "abcdef", "port", "43port"]
+INVALID_PORTS = ["443:80", "443:80:443", "abcdef", "port", "43port", " 1", "1 ", "𖭖", "-1", "　1", "1_1"]
 
 SNOWMAN = b"\xe2\x98\x83"
 SNOWMAN_IDNA_HOST = "http://xn--n3h.com"


### PR DESCRIPTION
Parsing port numbers with `int` allows port numbers to be
 - padded with whitespace (ASCII or unicode)
 - preceded by a plus or minus sign
 - interrupted with underscores
 - composed of unicode digits

None of these behaviors are permitted by any of the URL specifications. This PR adds a check to make sure that ports get rejected if they contain any characters that aren't ASCII digits.

A [similar bug](https://github.com/python/cpython/pull/98273) was recently fixed in CPython's urllib.parse module.