### PR TITLE
Declare support for Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,12 @@ jobs:
         - os: ubuntu-latest
           python: '3.10'
           toxenv: py
+        - os: ubuntu-latest
+          python: 3.11
+          toxenv: py
+        - os: ubuntu-latest
+          python: 3.12-dev
+          toxenv: py
         # windows
         - os: windows-latest
           python: 3.7
@@ -40,8 +46,8 @@ jobs:
           toxenv: pre-commit
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - run: python -mpip install --upgrade setuptools pip tox virtualenv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   main:
     strategy:
+      fail-fast: false
       matrix:
         include:
         # linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,29 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
+        python: [pypy3.7, 3.7, 3.9, "3.10", 3.11, 3.12-dev]
+        toxenv: [py]
         include:
-        # linux
-        - os: ubuntu-latest
-          python: pypy-3.7
-          toxenv: py
-        - os: ubuntu-latest
-          python: 3.7
-          toxenv: py
-        - os: ubuntu-latest
-          python: 3.8
-          toxenv: py
-        - os: ubuntu-latest
-          python: 3.9
-          toxenv: py
-        - os: ubuntu-latest
-          python: '3.10'
-          toxenv: py
-        - os: ubuntu-latest
-          python: 3.11
-          toxenv: py
-        - os: ubuntu-latest
-          python: 3.12-dev
-          toxenv: py
         # windows
         - os: windows-latest
           python: 3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.4.0
   hooks:
   - id: check-yaml
   - id: debug-statements
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.6.0
+  rev: v3.9.0
   hooks:
   - id: reorder-python-imports
     args: [--application-directories, '.:src', --py37-plus]
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 23.1.0
   hooks:
   - id: black
     args: [--line-length=79]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.0
+  rev: v3.3.1
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
+  rev: 6.0.0
   hooks:
   - id: flake8
     exclude: ^(tests/|docs/|setup.py)
@@ -30,9 +30,10 @@ repos:
     - flake8-docstrings
     - flake8-import-order
 - repo: https://github.com/asottile/setup-cfg-fmt
-  rev: v1.19.0
+  rev: v2.2.0
   hooks:
   - id: setup-cfg-fmt
+    args: [--include-version-classifiers]
 #- repo: https://github.com/pre-commit/mirrors-mypy
 #  rev: v0.910-1
 #  hooks:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ release = rfc3986.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
 
 [options]

--- a/tests/test_parseresult.py
+++ b/tests/test_parseresult.py
@@ -18,7 +18,19 @@ from . import base
 from rfc3986 import exceptions
 from rfc3986 import parseresult as pr
 
-INVALID_PORTS = ["443:80", "443:80:443", "abcdef", "port", "43port", " 1", "1 ", "𖭖", "-1", "　1", "1_1"]
+INVALID_PORTS = [
+    "443:80",
+    "443:80:443",
+    "abcdef",
+    "port",
+    "43port",
+    " 1",
+    "1 ",
+    "𖭖",
+    "-1",
+    "　1",
+    "1_1",
+]
 
 SNOWMAN = b"\xe2\x98\x83"
 SNOWMAN_IDNA_HOST = "http://xn--n3h.com"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -245,12 +245,12 @@ def test_allowed_hosts_and_schemes(uri, failed_component):
 )
 def test_successful_complex_validation(uri):
     """Verify we do not raise ValidationErrors for good URIs."""
-    validators.Validator().allow_schemes("https", "ssh",).allow_hosts(
+    validators.Validator().allow_schemes("https", "ssh").allow_hosts(
         "github.com",
         "bitbucket.org",
         "gitlab.com",
         "git.openstack.org",
-    ).allow_ports("22", "443",).require_presence_of(
+    ).allow_ports("22", "443").require_presence_of(
         "scheme",
         "host",
         "path",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,lint
+envlist = py{37,38,39,310,311,312},lint
 
 [testenv]
 pip_pre = False


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

And test 3.12-dev.

Whilst here, refactored the matrix to remove duplication for the main block.

---

Also needed to update Black to fix a Click issue, and add language to `conf.py` to fix:

```
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
```

