### PR TITLE
Inconsistent linting rules? [was Commit auto-reformatting from the linter]

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     {[testenv:flake8]deps}
     black
 commands =
-    black -l 78 {env:BLACK_ARGS:} -t py37 src/rfc3986 tests/
+    black -l 79 {env:BLACK_ARGS:} -t py37 src/rfc3986 tests/
     {[testenv:flake8]commands}
 
 [testenv:flake8]


### PR DESCRIPTION
When running the full set of tests using tox, flake8 makes these adjustments in place.

I encountered this while setting up tests for the other PR I'm about to submit, and figured it was best to submit the auto-formatting changes separate from my new change.

Tox runs cleanly after these changes:

```
---------- coverage: platform darwin, python 3.12.0-alpha-5 ----------
Name                                                             Stmts   Miss  Cover
------------------------------------------------------------------------------------
.tox/py312/lib/python3.12/site-packages/rfc3986/__init__.py         16      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/_mixin.py          112      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/abnf_regexp.py      63      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/api.py              15      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/builder.py          66      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/compat.py           10      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/exceptions.py       44      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/iri.py              50      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/misc.py             31      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/normalizers.py      80      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/parseresult.py     167      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/uri.py              30      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/validators.py      128      0   100%
------------------------------------------------------------------------------------
TOTAL                                                              812      0   100%

Required test coverage of 100% reached. Total coverage: 100.00%
2848 passed, 4947 warnings in 3.24s
.pkg: _exit> python /Users/handrews/dev/.venv/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py312: OK ✔ in 4.2 seconds
lint: commands[0]> black -l 78 -t py37 src/rfc3986 tests/
All done! ✨ 🍰 ✨
25 files left unchanged.
lint: commands[1]> flake8 src/rfc3986
  py37: OK (4.24=setup[1.01]+cmd[3.23] seconds)
  py38: OK (4.06=setup[0.67]+cmd[3.39] seconds)
  py39: OK (4.72=setup[1.44]+cmd[3.28] seconds)
  py310: OK (3.94=setup[0.70]+cmd[3.24] seconds)
  py311: OK (4.13=setup[0.79]+cmd[3.34] seconds)
  py312: OK (4.20=setup[0.73]+cmd[3.47] seconds)
  lint: OK (0.73=setup[0.01]+cmd[0.26,0.47] seconds)
  congratulations :) (26.14 seconds)
```