### PR TITLE
Don't use deprecated methods in resolve_with()

### DIFF
--- a/src/rfc3986/_mixin.py
+++ b/src/rfc3986/_mixin.py
@@ -56,6 +56,15 @@ class URIMixin:
     def _match_subauthority(self):
         return misc.SUBAUTHORITY_MATCHER.match(self.authority)
 
+    def _get_base_uri_validator(self):
+        try:
+            return self._base_uri_validator
+        except AttributeError:
+            self._base_uri_validator = (
+                validators.Validator().require_presence_of("scheme")
+            )
+            return self._base_uri_validator
+
     @property
     def host(self):
         """If present, a string representing the host."""
@@ -262,7 +271,9 @@ class URIMixin:
         if not isinstance(base_uri, URIMixin):
             base_uri = type(self).from_string(base_uri)
 
-        if not base_uri.is_valid(require_scheme=True):
+        try:
+            self._get_base_uri_validator().validate(base_uri)
+        except exc.ValidationError:
             raise exc.ResolutionError(base_uri)
 
         # This is optional per

--- a/src/rfc3986/_mixin.py
+++ b/src/rfc3986/_mixin.py
@@ -56,14 +56,15 @@ class URIMixin:
     def _match_subauthority(self):
         return misc.SUBAUTHORITY_MATCHER.match(self.authority)
 
-    def _get_base_uri_validator(self):
-        try:
-            return self._base_uri_validator
-        except AttributeError:
-            self._base_uri_validator = (
-                validators.Validator().require_presence_of("scheme")
-            )
-            return self._base_uri_validator
+    @property
+    def _validator(self):
+        v = getattr(self, "_cached_validator", None)
+        if v is not None:
+            return v
+        self._cached_validator = validators.Validator().require_presence_of(
+            "scheme"
+        )
+        return self._cached_validator
 
     @property
     def host(self):
@@ -272,7 +273,7 @@ class URIMixin:
             base_uri = type(self).from_string(base_uri)
 
         try:
-            self._get_base_uri_validator().validate(base_uri)
+            self._validator.validate(base_uri)
         except exc.ValidationError:
             raise exc.ResolutionError(base_uri)
 

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -363,6 +363,14 @@ class TestURIReferencesResolve:
         assert T.path is None
         assert T.query == "query"
 
+    def test_resolve_twice_for_cached_validator(self, basic_uri):
+        R = URIReference.from_string("")
+        B = URIReference.from_string(basic_uri)
+        T1 = R.resolve_with(B)
+        T2 = R.resolve_with(B)
+        assert T1 == T2
+        assert T1 == B
+
 
 def test_empty_querystrings_persist():
     url = "https://httpbin.org/get?"


### PR DESCRIPTION
Fixes #86: resolve_with(), which is not deprecated, was using the deprecated is_valid() method.  Replaced with a lazily instantiated validator object.

I'm happy to change this approach, it's just what first came to mind.  The linter was unhappy with the complexity of `resolve_with()` unless I moved the `self._base_uri_validator` instantiation check to its own method.

End of the tox output (run with 3.7.16, 3.8.13, 3.9.6, 3.10.10, 3.11.2, 3.12.0a5), run with this branch on top of the branch for PR #94 to avoid superfluous reformatting output:
```
---------- coverage: platform darwin, python 3.12.0-alpha-5 ----------
Name                                                             Stmts   Miss  Cover
------------------------------------------------------------------------------------
.tox/py312/lib/python3.12/site-packages/rfc3986/__init__.py         16      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/_mixin.py          112      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/abnf_regexp.py      63      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/api.py              15      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/builder.py          66      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/compat.py           10      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/exceptions.py       44      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/iri.py              50      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/misc.py             31      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/normalizers.py      80      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/parseresult.py     167      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/uri.py              30      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/validators.py      128      0   100%
------------------------------------------------------------------------------------
TOTAL                                                              812      0   100%

Required test coverage of 100% reached. Total coverage: 100.00%
2848 passed, 4947 warnings in 3.24s
.pkg: _exit> python /Users/handrews/dev/.venv/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py312: OK ✔ in 4.2 seconds
lint: commands[0]> black -l 78 -t py37 src/rfc3986 tests/
All done! ✨ 🍰 ✨
25 files left unchanged.
lint: commands[1]> flake8 src/rfc3986
  py37: OK (4.24=setup[1.01]+cmd[3.23] seconds)
  py38: OK (4.06=setup[0.67]+cmd[3.39] seconds)
  py39: OK (4.72=setup[1.44]+cmd[3.28] seconds)
  py310: OK (3.94=setup[0.70]+cmd[3.24] seconds)
  py311: OK (4.13=setup[0.79]+cmd[3.34] seconds)
  py312: OK (4.20=setup[0.73]+cmd[3.47] seconds)
  lint: OK (0.73=setup[0.01]+cmd[0.26,0.47] seconds)
  congratulations :) (26.14 seconds)
```

Note that `_mixin.py` was previously 112 statements, now 120.