### PR TITLE
Match empty path without using line begin/end

### DIFF
--- a/src/rfc3986/abnf_regexp.py
+++ b/src/rfc3986/abnf_regexp.py
@@ -150,7 +150,7 @@ segments = {
 }
 
 # Path types taken from Section 3.3 (linked above)
-PATH_EMPTY = "^$"
+PATH_EMPTY = "(?:)"
 PATH_ROOTLESS = "%(segment-nz)s(/%(segment)s)*" % segments
 PATH_NOSCHEME = "%(segment-nz-nc)s(/%(segment)s)*" % segments
 PATH_ABSOLUTE = "/(%s)?" % PATH_ROOTLESS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,16 @@ def uri_with_everything(request):
     )
 
 
+@pytest.fixture
+def uri_without_authority_with_empty_path():
+    return "about:"
+
+
+@pytest.fixture
+def uri_without_authority_with_query_only():
+    return "about:?foo=bar"
+
+
 @pytest.fixture(params=valid_hosts)
 def relative_uri(request):
     return "//%s" % request.param

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -269,6 +269,19 @@ class TestURIReferenceIsAbsolute:
         uri = URIReference.from_string(absolute_path_uri)
         assert uri.is_absolute() is False
 
+    def test_uris_with_no_authority_with_empty_path_are_absolute(
+        self,
+        uri_without_authority_with_empty_path,
+    ):
+        uri = URIReference.from_string(uri_without_authority_with_empty_path)
+
+    def test_uris_with_no_authority_with_query_only_are_absolute(
+        self,
+        uri_without_authority_with_query_only,
+    ):
+        uri = URIReference.from_string(uri_without_authority_with_query_only)
+        assert uri.is_absolute() is True
+
 
 # @pytest.fixture(params=[
 #     basic_uri, basic_uri_with_port, basic_uri_with_path,


### PR DESCRIPTION
Fixes #88: This change allows correctly recognizing URIs with a scheme, but no authority and an empty path (and possibly non-empty query or fragment) as absolute.  The "about:" URI scheme is a scheme that allows such syntax, as show in the linked issue.

This uses a non-capturing group as it was unclear if any code anywhere else was relying on capture group numbering from regexes that include the empty path regex.  I'm happy to change it if anyone has a better idea.

```
---------- coverage: platform darwin, python 3.12.0-alpha-5 ----------
Name                                                             Stmts   Miss  Cover
------------------------------------------------------------------------------------
.tox/py312/lib/python3.12/site-packages/rfc3986/__init__.py         16      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/_mixin.py          112      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/abnf_regexp.py      63      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/api.py              15      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/builder.py          66      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/compat.py           10      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/exceptions.py       44      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/iri.py              50      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/misc.py             31      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/normalizers.py      80      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/parseresult.py     167      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/uri.py              30      0   100%
.tox/py312/lib/python3.12/site-packages/rfc3986/validators.py      128      0   100%
------------------------------------------------------------------------------------
TOTAL                                                              812      0   100%

Required test coverage of 100% reached. Total coverage: 100.00%
2850 passed, 4947 warnings in 3.00s
.pkg: _exit> python /Users/handrews/dev/.venv/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py312: OK ✔ in 3.89 seconds
lint: commands[0]> black -l 78 -t py37 src/rfc3986 tests/
All done! ✨ 🍰 ✨
25 files left unchanged.
lint: commands[1]> flake8 src/rfc3986
  py37: OK (4.29=setup[1.05]+cmd[3.24] seconds)
  py38: OK (3.91=setup[0.69]+cmd[3.23] seconds)
  py39: OK (4.66=setup[1.44]+cmd[3.22] seconds)
  py310: OK (3.80=setup[0.70]+cmd[3.10] seconds)
  py311: OK (3.86=setup[0.68]+cmd[3.18] seconds)
  py312: OK (3.89=setup[0.67]+cmd[3.22] seconds)
  lint: OK (0.61=setup[0.01]+cmd[0.13,0.47] seconds)
  congratulations :) (25.12 seconds)
```