### PR TITLE
Stopped abnf regex from halting when it encounters a line terminator in the fragment

### DIFF
--- a/src/rfc3986/abnf_regexp.py
+++ b/src/rfc3986/abnf_regexp.py
@@ -42,7 +42,7 @@ SCHEME_RE = "[a-zA-Z][a-zA-Z0-9+.-]*"
 _AUTHORITY_RE = "[^\\\\/?#]*"
 _PATH_RE = "[^?#]*"
 _QUERY_RE = "[^#]*"
-_FRAGMENT_RE = ".*"
+_FRAGMENT_RE = "(?s:.*)"
 
 # Extracted from http://tools.ietf.org/html/rfc3986#appendix-B
 COMPONENT_PATTERN_DICT = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -134,6 +134,10 @@ class BaseTestParsesURIs:
         uri = self.test_class.from_string(uri_fragment_with_percent)
         assert uri.fragment == "perc%25ent"
 
+    def test_handles_line_terminators_in_fragment(self, uri_fragment_with_line_terminators):
+        """Test that self.test_class encodes line terminators in the fragment properly"""
+        ref = self.test_class.from_string(uri_fragment_with_line_terminators, 'utf-8')
+        assert ref.fragment == "%0Afrag%0Ament%0A"
 
 class BaseTestUnsplits:
     test_class = None

--- a/tests/base.py
+++ b/tests/base.py
@@ -134,10 +134,15 @@ class BaseTestParsesURIs:
         uri = self.test_class.from_string(uri_fragment_with_percent)
         assert uri.fragment == "perc%25ent"
 
-    def test_handles_line_terminators_in_fragment(self, uri_fragment_with_line_terminators):
+    def test_handles_line_terminators_in_fragment(
+        self, uri_fragment_with_line_terminators
+    ):
         """Test that self.test_class encodes line terminators in the fragment properly"""
-        ref = self.test_class.from_string(uri_fragment_with_line_terminators, 'utf-8')
+        ref = self.test_class.from_string(
+            uri_fragment_with_line_terminators, "utf-8"
+        )
         assert ref.fragment == "%0Afrag%0Ament%0A"
+
 
 class BaseTestUnsplits:
     test_class = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,9 +145,11 @@ def uri_query_with_percent(request):
 def uri_fragment_with_percent(request):
     return "https://%s#perc%%ent" % request.param
 
+
 @pytest.fixture(params=valid_hosts)
 def uri_fragment_with_line_terminators(request):
     return "https://%s#\nfrag\nment\n" % request.param
+
 
 @pytest.fixture(params=equivalent_schemes)
 def scheme_only(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,9 @@ def uri_query_with_percent(request):
 def uri_fragment_with_percent(request):
     return "https://%s#perc%%ent" % request.param
 
+@pytest.fixture(params=valid_hosts)
+def uri_fragment_with_line_terminators(request):
+    return "https://%s#\nfrag\nment\n" % request.param
 
 @pytest.fixture(params=equivalent_schemes)
 def scheme_only(request):


### PR DESCRIPTION
fixes #99 