### PR TITLE
Stops ParseResult.from_string from accepting ports not preceded by a ':' character

### DIFF
--- a/src/rfc3986/misc.py
+++ b/src/rfc3986/misc.py
@@ -51,7 +51,7 @@ SUBAUTHORITY_MATCHER = re.compile(
     (
         "^(?:(?P<userinfo>{})@)?"  # userinfo
         "(?P<host>{})"  # host
-        ":?(?P<port>{})?$"  # port
+        "(?::(?P<port>{}))?$"  # port
     ).format(
         abnf_regexp.USERINFO_RE, abnf_regexp.HOST_PATTERN, abnf_regexp.PORT_RE
     )

--- a/tests/base.py
+++ b/tests/base.py
@@ -156,7 +156,7 @@ class BaseTestParsesURIs:
                 raise AssertionError(
                     "No error thrown from URI with port but no colon"
                 )
-                
+
     def test_handles_line_terminators_in_fragment(
         self, uri_fragment_with_line_terminators
     ):
@@ -165,7 +165,7 @@ class BaseTestParsesURIs:
             uri_fragment_with_line_terminators, "utf-8"
         )
         assert ref.fragment == "%0Afrag%0Ament%0A"
-        
+
 
 class BaseTestUnsplits:
     test_class = None

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,8 +11,8 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from rfc3986 import exceptions as exc
+
 
 class BaseTestParsesURIs:
     test_class = None
@@ -142,7 +142,9 @@ class BaseTestParsesURIs:
             assert isinstance(e, exc.InvalidAuthority)
         else:
             if uri.port is not None:
-                raise AssertionError("No error thrown from URI with colon but no port")
+                raise AssertionError(
+                    "No error thrown from URI with colon but no port"
+                )
 
     def test_handles_port_but_no_colon(self, uri_with_port_but_no_colon):
         try:
@@ -151,7 +153,9 @@ class BaseTestParsesURIs:
             assert isinstance(e, exc.InvalidAuthority)
         else:
             if uri.port is not None:
-                raise AssertionError("No error thrown from URI with port but no colon")
+                raise AssertionError(
+                    "No error thrown from URI with port but no colon"
+                )
 
 
 class BaseTestUnsplits:

--- a/tests/base.py
+++ b/tests/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rfc3986 import exceptions as exc
 
 class BaseTestParsesURIs:
     test_class = None
@@ -133,6 +134,24 @@ class BaseTestParsesURIs:
     def test_handles_percent_in_fragment(self, uri_fragment_with_percent):
         uri = self.test_class.from_string(uri_fragment_with_percent)
         assert uri.fragment == "perc%25ent"
+
+    def test_handles_colon_but_no_port(self, uri_with_colon_but_no_port):
+        try:
+            uri = self.test_class.from_string(uri_with_colon_but_no_port)
+        except Exception as e:
+            assert isinstance(e, exc.InvalidAuthority)
+        else:
+            if uri.port is not None:
+                raise AssertionError("No error thrown from URI with colon but no port")
+
+    def test_handles_port_but_no_colon(self, uri_with_port_but_no_colon):
+        try:
+            uri = self.test_class.from_string(uri_with_port_but_no_colon)
+        except Exception as e:
+            assert isinstance(e, exc.InvalidAuthority)
+        else:
+            if uri.port is not None:
+                raise AssertionError("No error thrown from URI with port but no colon")
 
 
 class BaseTestUnsplits:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,16 @@ def uri_without_authority_with_query_only():
     return "about:?foo=bar"
 
 
+@pytest.fixture
+def uri_with_colon_but_no_port():
+    return "scheme://user@[v12.ip]:/path"
+
+
+@pytest.fixture
+def uri_with_port_but_no_colon():
+    return "scheme://user@[v12.ip]8000/path"
+
+
 @pytest.fixture(params=valid_hosts)
 def relative_uri(request):
     return "//%s" % request.param


### PR DESCRIPTION
Fixes #102 