### PR TITLE
Include tox.ini in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include LICENSE
 include AUTHORS.rst
 include setup.cfg
+include tox.ini
 prune *.pyc
 recursive-include docs *.rst *.py
 recursive-include tests *.py


### PR DESCRIPTION
## Summary

- include `tox.ini` in the source distribution manifest
- keep downstream packagers able to run the bundled tox configuration from an sdist

Closes #129.

## Validation

- Not run locally
- Static validation only: `git diff --check`.
- Relying on the repository's GitHub Actions checks for remote validation.