### PR TITLE
Document composing IP host patterns

### DIFF
--- a/docs/source/api-ref/miscellaneous.rst
+++ b/docs/source/api-ref/miscellaneous.rst
@@ -136,6 +136,22 @@ regular expressions.
     - :data:`rfc3986.abnf_regexp.IPv4_RE`
     - :data:`rfc3986.abnf_regexp.IP_LITERAL_RE`
 
+    Consumers that need to distinguish IP address hosts from registered names
+    can compose the IP address alternatives directly:
+
+    .. code-block:: python
+
+        import re
+
+        from rfc3986 import abnf_regexp
+
+        IP_HOST_RE = re.compile(
+            "^({}|{})$".format(
+                abnf_regexp.IPv4_RE,
+                abnf_regexp.IP_LITERAL_RE,
+            )
+        )
+
     See :rfc:`3986#section-3.2.2`.
 
 .. data:: rfc3986.abnf_regexp.USERINFO_RE


### PR DESCRIPTION
## Summary
- document how to compose an IP-address-only host regex from `IPv4_RE` and `IP_LITERAL_RE`
- keep the guidance in the existing `HOST_PATTERN` API reference instead of adding a new public constant

Closes #41

## Validation
- Not run locally
- Static validation only: `git diff --check`