### PR TITLE
Keep a // path from becoming an authority on unsplit

### DIFF
--- a/src/rfc3986/_mixin.py
+++ b/src/rfc3986/_mixin.py
@@ -363,7 +363,14 @@ class URIMixin:
         if self.authority:
             result_list.extend(["//", self.authority])
         if self.path:
-            result_list.append(self.path)
+            path = self.path
+            # A path that starts with "//" is a network-path reference
+            # (RFC 3986 §4.2). Without an authority, reconstituting it
+            # as-is would produce "scheme://host" and the next parse
+            # would steal the first segment as the authority.
+            if path.startswith("//") and not self.authority:
+                path = "/." + path
+            result_list.append(path)
         if self.query is not None:
             result_list.extend(["?", self.query])
         if self.fragment is not None:

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -153,6 +153,17 @@ class TestURIReferenceUnsplits(base.BaseTestUnsplits):
         uri = self.test_class.from_string(scheme_and_path_uri)
         assert uri.unsplit() == scheme_and_path_uri
 
+    def test_normalize_does_not_invent_an_authority(self):
+        # scheme:/..///bar has no authority. Removing dot-segments leaves
+        # path "//bar"; unsplitting that as-is becomes scheme://bar.
+        uri = self.test_class.from_string("scheme:/..///bar")
+        assert uri.authority is None
+        normalized = uri.normalize()
+        assert normalized.authority is None
+        rebuilt = self.test_class.from_string(normalized.unsplit())
+        assert rebuilt.authority is None
+        assert rebuilt.scheme == "scheme"
+
 
 class TestURIReferenceComparesToStrings:
     def test_basic_uri(self, basic_uri):


### PR DESCRIPTION
`scheme:/..///bar` has no authority. Removing dot-segments leaves path `//bar`, and `unsplit()` then emits `scheme://bar`. Parsing that string treats `bar` as the host.

If there is no authority and the path starts with `//`, prefix `/.` so the reconstituted URI still has no host. Same idea as the WHATWG serializer for a path whose first segment is empty.

```python
>>> from rfc3986 import uri_reference
>>> uri_reference("scheme:/..///bar").normalize().unsplit()
# before: "scheme://bar"
# after:  "scheme:/.//bar"
>>> uri_reference("scheme:/.//bar").authority
None
```
